### PR TITLE
Disable OldTargetApi lint check - fails CI on new Android releases

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -57,7 +57,13 @@ android {
         warningsAsErrors = true
         // "A newer version is available" checks break CI on upstream
         // releases without any code change - versions are bumped deliberately
-        disable += listOf("GradleDependency", "AndroidGradlePluginVersion", "NewerVersionAvailable")
+        disable +=
+            listOf(
+                "GradleDependency",
+                "AndroidGradlePluginVersion",
+                "NewerVersionAvailable",
+                "OldTargetApi",
+            )
     }
 }
 

--- a/android-app/app/lint-baseline.xml
+++ b/android-app/app/lint-baseline.xml
@@ -13,17 +13,6 @@
     </issue>
 
     <issue
-        id="OldTargetApi"
-        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the `android.os.Build.VERSION_CODES` javadoc for details."
-        errorLine1="targetSdk = &quot;34&quot;"
-        errorLine2="            ~~~~">
-        <location
-            file="$HOME/git/ble-browser-android-bridge/android-app/gradle/libs.versions.toml"
-            line="17"
-            column="13"/>
-    </issue>
-
-    <issue
         id="UseAppTint"
         message="Must use `app:tint` instead of `android:tint`"
         errorLine1="            android:tint=&quot;#FFFFFF&quot; />"


### PR DESCRIPTION
The APK build workflow failed on main (run 29289920684) because the
OldTargetApi lint check fired on CI: it flags that targetSdk 34 is not the
latest Android version. Like the already-disabled GradleDependency /
AndroidGradlePluginVersion checks, it starts failing whenever upstream
releases something new, with zero code change - and its baseline entry did
not match across machines either. targetSdk bumps should be deliberate,
tested changes instead.

- add OldTargetApi to the disabled lint checks (with rationale comment)
- regenerate the lint baseline (58 frozen findings)

Verified locally: lintDebug, ktlintCheck and the 14 unit tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)